### PR TITLE
fix: add exports types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/react-nodetoy.es.js",
-      "require": "./dist/react-nodetoy.umd.js"
+      "require": "./dist/react-nodetoy.umd.js",
+      "types": "./dist/NodeToy.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
When importing from `@nodetoy/react-nodetoy` with `"moduleResolution": "Bundler"` in tsconfig.json, types cannot be resolved :
![image](https://github.com/NodeToy/react-nodetoy/assets/32564108/8023108e-ef89-4238-a1e8-ceb2f4e8324f)

This is a simple fix
