### PR TITLE
Export as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@nodetoy/react-nodetoy",
-  "version": "0.1.24",
+  "version": "1.0.0",
   "files": [
     "dist"
   ],
+  "type": "module",
   "types": "./dist/NodeToy.d.ts",
   "main": "./dist/react-nodetoy.umd.js",
   "module": "./dist/react-nodetoy.es.js",


### PR DESCRIPTION
`"type": "module"` allows users to use this library like:

```tsx
import { NodeToyMaterial } from "@nodetoy/three-nodetoy";
```

Otherwise, you run into import errors.

Maybe this works as is in some other frameworks but in a fresh SvelteKit project it breaks with this untouched SvelteKit tsconfig:

```json
{
	"extends": "./.svelte-kit/tsconfig.json",
	"compilerOptions": {
		"allowJs": true,
		"checkJs": true,
		"esModuleInterop": true,
		"forceConsistentCasingInFileNames": true,
		"resolveJsonModule": true,
		"skipLibCheck": true,
		"sourceMap": true,
		"strict": true
	}
	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
	//
	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
	// from the referenced tsconfig.json - TypeScript does not merge them in
}
```

---

This also does a major version bump to `1.0.0` since it's possible this might break someone's pre-existing build.